### PR TITLE
Make PHP tools as suggestion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,10 @@
     ],
     "require": {
         "php": ">=5.4",
+        "misumirize/git-validate": "~0.1",
+    },
+    "suggest": {
         "fabpot/php-cs-fixer": "*",
-        "misumirize/git-validate": "0.1.*",
         "phpmd/phpmd": "*",
         "phpunit/phpunit": "*"
     },


### PR DESCRIPTION
PHP tools should be suggested and not required.

Concrete case example: If a project use phpspec instead of phpunit, using your package would install useless and unused phpunit package.

Regards.
